### PR TITLE
Add satellite create command for omnibus installs

### DIFF
--- a/doc/raketasks/maintenance.md
+++ b/doc/raketasks/maintenance.md
@@ -117,6 +117,12 @@ This will create satellite repositories for all your projects.
 
 If necessary, remove the `repo_satellites` directory and rerun the commands below.
 
+For Omnibus-packages:
+```
+sudo gitlab-rake gitlab:satellites:create
+```
+
+For installations from source:
 ```
 sudo -u git -H mkdir -p /home/git/gitlab-satellites
 sudo -u git -H bundle exec rake gitlab:satellites:create RAILS_ENV=production


### PR DESCRIPTION
In at least the 7.9.1 omnibus release and after I was able to use the `gitlab-rake` command
to rebuild the satellites, rather than using bundle directly. This doc entry brings the
satellite section into alignment with the other sections in the doc which show both the
use of gitlab-rake and the direct execution of the rake task via bundle.
